### PR TITLE
Fix ServiceOrder notification relationship error

### DIFF
--- a/apps/core/notifications.py
+++ b/apps/core/notifications.py
@@ -112,7 +112,7 @@ def send_order_created_notification(order, tenant=None):
         'order': order,
         'customer': order.customer,
         'vehicle': order.vehicle,
-        'services': order.serviceorderitem_set.all(),
+        'services': order.order_items.all(),
         'notification_type': 'created'
     }
     
@@ -144,7 +144,7 @@ def send_order_started_notification(order, attendant_name=None, tenant=None):
         'order': order,
         'customer': order.customer,
         'vehicle': order.vehicle,
-        'services': order.serviceorderitem_set.all(),
+        'services': order.order_items.all(),
         'attendant_name': attendant_name,
         'notification_type': 'started'
     }
@@ -177,7 +177,7 @@ def send_order_completed_notification(order, attendant_name=None, tenant=None):
         'order': order,
         'customer': order.customer,
         'vehicle': order.vehicle,
-        'services': order.serviceorderitem_set.all(),
+        'services': order.order_items.all(),
         'attendant_name': attendant_name,
         'notification_type': 'completed'
     }


### PR DESCRIPTION
- Fixed AttributeError: 'ServiceOrder' object has no attribute 'serviceorderitem_set'
- Updated all notification functions to use correct 'order_items' relationship
- Changed order.serviceorderitem_set.all() to order.order_items.all() in:
  - send_order_created_notification()
  - send_order_started_notification()
  - send_order_completed_notification()
- Resolves quick order creation notification errors