### PR TITLE
Fix TenantSettings migration issue for cPanel deployment

### DIFF
--- a/apps/core/tenant_models.py
+++ b/apps/core/tenant_models.py
@@ -6,6 +6,7 @@ from django.db import models
 from django.contrib.auth.models import User
 from django.core.validators import RegexValidator
 from django.utils.text import slugify
+from django.utils import timezone as django_timezone
 from phonenumber_field.modelfields import PhoneNumberField
 from apps.core.models import TimeStampedModel, Address, ContactInfo
 import uuid
@@ -318,7 +319,7 @@ class TenantSettings(models.Model):
     twitter_url = models.URLField(blank=True)
     
     # Timestamps
-    created_at = models.DateTimeField(auto_now_add=True)
+    created_at = models.DateTimeField(default=django_timezone.now)
     updated_at = models.DateTimeField(auto_now=True)
     
     class Meta:


### PR DESCRIPTION
 Migration Fix:
- Fixed AttributeError with timezone import conflicting with model field
- Changed created_at field from auto_now_add=True to default=django_timezone.now
- This provides a default value for existing TenantSettings records
- Prevents interactive migration prompts in cPanel environment

 Generated Migrations:
- 0003_auto_20250820_1321.py (empty migration)
- 0004_alter_tenantsettings_created_at.py (field alteration)

 cPanel Compatibility:
- Non-interactive migrations that can run automatically
- Resolves 'EOF when reading a line' error in cPanel
- Handles existing database records properly
- Maintains proper timestamp functionality